### PR TITLE
HOMS-463 Log SSO auth errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v2.8.3 [unreleased]
+### Refactoring
+- [#712](https://github.com/hydra-billing/homs/pull/712) Log SSO authentication errors with stacktrace.
+
 v2.8.0 [2023-03-07]
 -------------------
 ### Breaking changes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,7 +238,7 @@ GEM
       haml (>= 4.0)
       nokogiri (>= 1.6.0)
       ruby_parser (~> 3.5)
-    hydra-keycloak-client (0.1.18)
+    hydra-keycloak-client (0.1.19)
       dry-auto_inject
       dry-container
       dry-monads


### PR DESCRIPTION
Like this
```
[HOMS] I, [2023-07-27T17:18:08.745975 #51487]  INFO -- : Started GET "/authenticate_by_keycloak?session_state=6d47cfb3-c1f4-4db8-a73f-b25cbce027f2&code=84cc92a0-651f-4572-be87-bb3b78064884.6d47cfb3-c1f4-4db8-a73f-b25cbce027f2.03f81625-cf8c-4e09-b408-d1a3e2acadea" for ::1 at 2023-07-27 17:18:08 +0300
[HOMS] I, [2023-07-27T17:18:08.772136 #51487]  INFO -- : Processing by SessionsController#authenticate_by_keycloak as HTML
[HOMS] I, [2023-07-27T17:18:08.772344 #51487]  INFO -- :   Parameters: {"session_state"=>"6d47cfb3-c1f4-4db8-a73f-b25cbce027f2", "code"=>"84cc92a0-651f-4572-be87-bb3b78064884.6d47cfb3-c1f4-4db8-a73f-b25cbce027f2.03f81625-cf8c-4e09-b408-d1a3e2acadea"}
[HOMS] E, [2023-07-27T17:18:08.812522 #51487] ERROR -- : Keycloak authentication error: {:code=>:redis_unavailable, :context=>{:args=>{:key=>"6d47cfb3-c1f4-4db8-a73f-b25cbce027f2_access_token"}, :action=>:get, :error=>"Error connecting to Redis on localhost:6379 (Errno::ECONNREFUSED)", :caller=>["/Users/talekperov/dev/hydra-keycloak-client/lib/hydra/keycloak/store/redis_client.rb:23:in `get'", "/Users/talekperov/dev/hydra-keycloak-client/lib/hydra/keycloak/store/gateway.rb:17:in `get'", "/Users/talekperov/dev/hydra-keycloak-client/lib/hydra/keycloak/client.rb:216:in `fetch_token'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/dry-monads-1.6.0/lib/dry/monads/do.rb:131:in `block in fetch_token'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/dry-monads-1.6.0/lib/dry/monads/do/mixin.rb:40:in `call'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/dry-monads-1.6.0/lib/dry/monads/do.rb:131:in `fetch_token'", "/Users/talekperov/dev/hydra-keycloak-client/lib/hydra/keycloak/client.rb:179:in `access_token'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/dry-monads-1.6.0/lib/dry/monads/do.rb:131:in `block in access_token'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/dry-monads-1.6.0/lib/dry/monads/do/mixin.rb:40:in `call'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/dry-monads-1.6.0/lib/dry/monads/do.rb:131:in `access_token'", "/Users/talekperov/dev/homs/app/controllers/application_controller.rb:31:in `keycloak_user'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/dry-monads-1.6.0/lib/dry/monads/do.rb:131:in `block in keycloak_user'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/dry-monads-1.6.0/lib/dry/monads/do/mixin.rb:40:in `call'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/dry-monads-1.6.0/lib/dry/monads/do.rb:131:in `keycloak_user'", "/Users/talekperov/dev/homs/app/controllers/sessions_controller.rb:70:in `get_user'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/dry-monads-1.6.0/lib/dry/monads/do.rb:131:in `block in get_user'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/dry-monads-1.6.0/lib/dry/monads/do/mixin.rb:40:in `call'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/dry-monads-1.6.0/lib/dry/monads/do.rb:131:in `get_user'", "/Users/talekperov/dev/homs/app/controllers/sessions_controller.rb:45:in `authenticate_by_keycloak'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/actionpack-5.2.8.1/lib/action_controller/metal/basic_implicit_render.rb:6:in `send_action'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/actionpack-5.2.8.1/lib/abstract_controller/base.rb:194:in `process_action'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/actionpack-5.2.8.1/lib/action_controller/metal/rendering.rb:30:in `process_action'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/actionpack-5.2.8.1/lib/abstract_controller/callbacks.rb:42:in `block in process_action'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/callbacks.rb:132:in `run_callbacks'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/actionpack-5.2.8.1/lib/abstract_controller/callbacks.rb:41:in `process_action'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/actionpack-5.2.8.1/lib/action_controller/metal/rescue.rb:22:in `process_action'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/actionpack-5.2.8.1/lib/action_controller/metal/instrumentation.rb:34:in `block in process_action'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/notifications.rb:168:in `block in instrument'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/notifications/instrumenter.rb:23:in `instrument'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/notifications.rb:168:in `instrument'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/actionpack-5.2.8.1/lib/action_controller/metal/instrumentation.rb:32:in `process_action'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/actionpack-5.2.8.1/lib/action_controller/metal/params_wrapper.rb:256:in `process_action'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/activerecord-5.2.8.1/lib/active_record/railties/controller_runtime.rb:24:in `process_action'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/actionpack-5.2.8.1/lib/abstract_controller/base.rb:134:in `process'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/actionview-5.2.8.1/lib/action_view/rendering.rb:32:in `process'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/actionpack-5.2.8.1/lib/action_controller/metal.rb:191:in `dispatch'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/actionpack-5.2.8.1/lib/action_controller/metal.rb:252:in `dispatch'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/actionpack-5.2.8.1/lib/action_dispatch/routing/route_set.rb:52:in `dispatch'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/actionpack-5.2.8.1/lib/action_dispatch/routing/route_set.rb:34:in `serve'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/actionpack-5.2.8.1/lib/action_dispatch/routing/mapper.rb:18:in `block in <class:Constraints>'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/actionpack-5.2.8.1/lib/action_dispatch/routing/mapper.rb:48:in `serve'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/actionpack-5.2.8.1/lib/action_dispatch/journey/router.rb:52:in `block in serve'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/actionpack-5.2.8.1/lib/action_dispatch/journey/router.rb:35:in `each'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/actionpack-5.2.8.1/lib/action_dispatch/journey/router.rb:35:in `serve'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/actionpack-5.2.8.1/lib/action_dispatch/routing/route_set.rb:840:in `call'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/warden-1.2.9/lib/warden/manager.rb:36:in `block in call'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/warden-1.2.9/lib/warden/manager.rb:34:in `catch'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/warden-1.2.9/lib/warden/manager.rb:34:in `call'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/rack-2.2.7/lib/rack/tempfile_reaper.rb:15:in `call'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/rack-2.2.7/lib/rack/etag.rb:27:in `call'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/rack-2.2.7/lib/rack/conditional_get.rb:27:in `call'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/rack-2.2.7/lib/rack/head.rb:12:in `call'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/actionpack-5.2.8.1/lib/action_dispatch/http/content_security_policy.rb:18:in `call'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/rack-2.2.7/lib/rack/session/abstract/id.rb:266:in `context'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/rack-2.2.7/lib/rack/session/abstract/id.rb:260:in `call'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/actionpack-5.2.8.1/lib/action_dispatch/middleware/cookies.rb:670:in `call'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/activerecord-5.2.8.1/lib/active_record/migration.rb:559:in `call'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/actionpack-5.2.8.1/lib/action_dispatch/middleware/callbacks.rb:28:in `block in call'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/callbacks.rb:98:in `run_callbacks'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/actionpack-5.2.8.1/lib/action_dispatch/middleware/callbacks.rb:26:in `call'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/actionpack-5.2.8.1/lib/action_dispatch/middleware/executor.rb:14:in `call'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/better_errors-2.10.1/lib/better_errors/middleware.rb:87:in `protected_app_call'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/better_errors-2.10.1/lib/better_errors/middleware.rb:82:in `better_errors_call'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/better_errors-2.10.1/lib/better_errors/middleware.rb:60:in `call'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/actionpack-5.2.8.1/lib/action_dispatch/middleware/debug_exceptions.rb:61:in `call'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/actionpack-5.2.8.1/lib/action_dispatch/middleware/show_exceptions.rb:33:in `call'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/rack/logger.rb:38:in `call_app'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/rack/logger.rb:26:in `block in call'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/tagged_logging.rb:71:in `block in tagged'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/tagged_logging.rb:28:in `tagged'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/tagged_logging.rb:71:in `tagged'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/rack/logger.rb:26:in `call'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/actionpack-5.2.8.1/lib/action_dispatch/middleware/remote_ip.rb:81:in `call'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/actionpack-5.2.8.1/lib/action_dispatch/middleware/request_id.rb:27:in `call'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/rack-2.2.7/lib/rack/method_override.rb:24:in `call'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/rack-2.2.7/lib/rack/runtime.rb:22:in `call'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/actionpack-5.2.8.1/lib/action_dispatch/middleware/executor.rb:14:in `call'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/actionpack-5.2.8.1/lib/action_dispatch/middleware/static.rb:127:in `call'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/rack-2.2.7/lib/rack/sendfile.rb:110:in `call'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/engine.rb:524:in `call'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/puma-5.6.6/lib/puma/configuration.rb:252:in `call'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/puma-5.6.6/lib/puma/request.rb:77:in `block in handle_request'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/puma-5.6.6/lib/puma/thread_pool.rb:340:in `with_force_shutdown'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/puma-5.6.6/lib/puma/request.rb:76:in `handle_request'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/puma-5.6.6/lib/puma/server.rb:443:in `process_client'", "/Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/puma-5.6.6/lib/puma/thread_pool.rb:147:in `block in spawn_thread'"]}}
[HOMS] I, [2023-07-27T17:18:08.816071 #51487]  INFO -- : Redirected to http://localhost:3000/users/sign_in
[HOMS] I, [2023-07-27T17:18:08.816212 #51487]  INFO -- : Completed 302 Found in 44ms (ActiveRecord: 0.0ms)


[HOMS] I, [2023-07-27T17:18:08.821339 #51487]  INFO -- : Started GET "/users/sign_in" for ::1 at 2023-07-27 17:18:08 +0300
[HOMS] I, [2023-07-27T17:18:08.839309 #51487]  INFO -- : Processing by SessionsController#new as HTML
[HOMS] I, [2023-07-27T17:18:08.845775 #51487]  INFO -- :   Rendering devise/sessions/new.html.erb within layouts/application
[HOMS] I, [2023-07-27T17:18:08.848941 #51487]  INFO -- :   Rendered /Users/talekperov/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/devise-4.9.2/app/views/devise/shared/_error_messages.html.erb (0.4ms)
[HOMS] I, [2023-07-27T17:18:08.850091 #51487]  INFO -- :   Rendered devise/sessions/new.html.erb within layouts/application (4.2ms)
[HOMS] I, [2023-07-27T17:18:08.969109 #51487]  INFO -- :   Rendered layouts/_navigation.html.haml (10.9ms)
[HOMS] I, [2023-07-27T17:18:09.070396 #51487]  INFO -- : Completed 200 OK in 231ms (Views: 228.9ms | ActiveRecord: 0.0ms)
```