### PR TITLE
HBW-398 Fix tests for v2.8

### DIFF
--- a/hbw/app/models/hbw/fields/services_table.rb
+++ b/hbw/app/models/hbw/fields/services_table.rb
@@ -139,8 +139,8 @@ module HBW
 
       def get_db_value
         sql = get_db_value_sql % {
-          account_id:,
-          contract_id:,
+          account_id:      account_id,
+          contract_id:     contract_id,
           equipment_types: equipment.map { |equipment_entry| equipment_entry.fetch('id').to_i }.join(',')
         }
         db_value = loader(sql, {}).load
@@ -195,28 +195,28 @@ module HBW
       end
 
       def as_json
-        {name:,
-         value:,
-         type:,
-         label:,
-         css_class:,
-         label_css:,
+        {name:               name,
+         value:              value,
+         type:               type,
+         label:              label,
+         css_class:          css_class,
+         label_css:          label_css,
          nullable:           nullable?,
          editable:           editable?,
          delimiter:          delimiter?,
-         delete_if:,
-         disable_if:,
-         dynamic:,
-         variables:,
+         delete_if:          delete_if,
+         disable_if:         disable_if,
+         dynamic:            dynamic,
+         variables:          variables,
          current_value:      value,
-         customer_id:,
-         account_id:,
-         contract_id:,
-         currency_code:,
+         customer_id:        customer_id,
+         account_id:         account_id,
+         contract_id:        contract_id,
+         currency_code:      currency_code,
          equipment_types:    equipment,
          individual_pricing: individual_pricing?,
-         hidden_columns:,
-         date_format:}
+         hidden_columns:     hidden_columns,
+         date_format:        date_format}
       end
 
       def loader(condition, variables)
@@ -257,7 +257,7 @@ module HBW
       end
 
       def get_bpm_prop_value(prop_name, default_value = nil, required: true)
-        variable_name = get_definition_prop_value(prop_name, default_value, required:)
+        variable_name = get_definition_prop_value(prop_name, default_value, required: required)
         if variable_name == default_value
           return default_value
         end

--- a/hbw/lib/const.rb
+++ b/hbw/lib/const.rb
@@ -15,5 +15,4 @@ module CONST
     const_set(name, value)
     value
   end
-
 end

--- a/spec/hbw/features/bp_form/services_select_spec.rb
+++ b/spec/hbw/features/bp_form/services_select_spec.rb
@@ -3,7 +3,7 @@ feature 'Check services select table', js: true do
     set_camunda_api_mock_file('spec/hbw/features/bp_form/services_select_mock.yml')
 
     order_type = FactoryBot.create(:order_type, :support_request)
-    FactoryBot.create(:order, order_type:) # ORD-1
+    FactoryBot.create(:order, order_type: order_type) # ORD-1
     user = FactoryBot.create(:user)
 
     signin(user.email, user.password)


### PR DESCRIPTION
```
Check services select table
Capybara starting Puma...
* Version 5.6.5 , codename: Birdie's Version
* Min threads: 0, max threads: 4
* Listening on http://127.0.0.1:52298
/Users/ekrasnov/Documents/sources/HBW-398/homs/app/controllers/sessions_controller.rb:116: warning: Pattern matching is experimental, and the behavior may change in future versions of Ruby!
  should contain required subscriptions

Top 1 slowest examples (20.58 seconds, 94.5% of total time):
  Check services select table should contain required subscriptions
    20.58 seconds ./spec/hbw/features/bp_form/services_select_spec.rb:16

Finished in 21.77 seconds (files took 11.63 seconds to load)
1 example, 0 failures
```